### PR TITLE
Bump Dependency to `go-renogy-modbus` v1.0.1 -> v1.0.2

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -1,7 +1,7 @@
 ---
 name: Upload Image
 
-on:   # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   release:
     types:
       - created

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -1,7 +1,7 @@
 ---
 name: Upload Image
 
-on:  # yamllint disable-line rule:truthy
+on:   # yamllint disable-line rule:truthy
   release:
     types:
       - created
@@ -41,7 +41,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and Push to Artifact Registry and Container Registry
+      - name: Build and Push to Container Registry
         uses: docker/build-push-action@v3
         with:
           push: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.3"
 services:
   main:
     build: .
-    privileged: true # required for passing through /dev
+    privileged: true  # required for passing through /dev
     ports:
       - "8080:8080"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/knadh/koanf/providers/env v0.1.0
 	github.com/knadh/koanf/v2 v2.0.1
-	github.com/michaelpeterswa/go-renogy-modbus v1.0.1
+	github.com/michaelpeterswa/go-renogy-modbus v1.0.2
 	github.com/prometheus/client_golang v1.12.2
 	github.com/robfig/cron/v3 v3.0.0
 	go.uber.org/zap v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/michaelpeterswa/go-renogy-modbus v1.0.1 h1:0wCs1quiixMqbLiPrNqlXirg77XQnhGj1Vec9Rhs8CA=
 github.com/michaelpeterswa/go-renogy-modbus v1.0.1/go.mod h1:4UicTQPLkeBTBCtmsoJrOnPUA953JuELWfETJTgh8cE=
+github.com/michaelpeterswa/go-renogy-modbus v1.0.2 h1:EdgFljr+kLU1NcwuBTZgz29bzbNyXh7f66kfnsJ2+Ks=
+github.com/michaelpeterswa/go-renogy-modbus v1.0.2/go.mod h1:4UicTQPLkeBTBCtmsoJrOnPUA953JuELWfETJTgh8cE=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
- fix: bump go-renogy-modbus dependency
- chore: add space for yamllint
