### PR TITLE
Bump `go-renogy-modbus` from v1.0.2 -> v1.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/knadh/koanf/providers/env v0.1.0
 	github.com/knadh/koanf/v2 v2.0.1
-	github.com/michaelpeterswa/go-renogy-modbus v1.0.2
+	github.com/michaelpeterswa/go-renogy-modbus v1.0.3
 	github.com/prometheus/client_golang v1.12.2
 	github.com/robfig/cron/v3 v3.0.0
 	go.uber.org/zap v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/michaelpeterswa/go-renogy-modbus v1.0.1 h1:0wCs1quiixMqbLiPrNqlXirg77
 github.com/michaelpeterswa/go-renogy-modbus v1.0.1/go.mod h1:4UicTQPLkeBTBCtmsoJrOnPUA953JuELWfETJTgh8cE=
 github.com/michaelpeterswa/go-renogy-modbus v1.0.2 h1:EdgFljr+kLU1NcwuBTZgz29bzbNyXh7f66kfnsJ2+Ks=
 github.com/michaelpeterswa/go-renogy-modbus v1.0.2/go.mod h1:4UicTQPLkeBTBCtmsoJrOnPUA953JuELWfETJTgh8cE=
+github.com/michaelpeterswa/go-renogy-modbus v1.0.3 h1:xGJAqxVH0Wc48mfmPyr5EyQhr5p7sXM9kpTb/DVXZxY=
+github.com/michaelpeterswa/go-renogy-modbus v1.0.3/go.mod h1:4UicTQPLkeBTBCtmsoJrOnPUA953JuELWfETJTgh8cE=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
- fix: bump go-renogy-modbus dependency
- chore: add space for yamllint
- fix: bump deps again
